### PR TITLE
Improve navigation across docs pages

### DIFF
--- a/docs-api/sidebar.js
+++ b/docs-api/sidebar.js
@@ -9,6 +9,11 @@
 const sidebars = {
   api: [
     {
+      type: 'link',
+      label: '← All documentation',
+      href: '/',
+    },
+    {
       type: 'doc',
       id: 'index',
       label: 'API Overview',

--- a/docs-platform/sidebar.js
+++ b/docs-platform/sidebar.js
@@ -9,6 +9,11 @@
 const sidebars = {
   platform: [
     {
+      type: 'link',
+      label: '← All documentation',
+      href: '/',
+    },
+    {
       type: 'doc',
       id: 'index',
       label: 'Platform Overview',

--- a/docs-sdk/sidebar.js
+++ b/docs-sdk/sidebar.js
@@ -9,6 +9,11 @@
 const sidebars = {
   sdk: [
     {
+      type: 'link',
+      label: '← All documentation',
+      href: '/',
+    },
+    {
       type: 'doc',
       id: 'index',
       label: 'SDK Overview',

--- a/src/theme/DocBreadcrumbs/index.tsx
+++ b/src/theme/DocBreadcrumbs/index.tsx
@@ -220,7 +220,7 @@ export default function DocBreadcrumbs() {
               </BreadcrumbsItem>
             );
           })}
-          <DocumentationDropdown />
+          {/*<DocumentationDropdown />*/}
         </ul>
       </nav>
     </>


### PR DESCRIPTION
What

Changes include:
- Removing the “Documentation” dropdown displayed above page titles.
- Adding a consistent “← All documentation” link at the top of Platform, API, SDK, and CLI sidebars to allow users to easily return to the main documentation view.

Why

The breadcrumb dropdown was confusing and hid key navigation options.
Additionally, switching into Platform/API/SDK/CLI views replaced the main sidebar, making it difficult for users to navigate back.
